### PR TITLE
Fix native charachter '<, >' to named entity

### DIFF
--- a/started/2_try/8_configuration.md
+++ b/started/2_try/8_configuration.md
@@ -10,7 +10,7 @@ published: true
 
 ## Authentication using LDAP
 FOSSLight uses JNDI to support user password authentication using LDAP in an environment where LDAP such as Active Directory can be used.
-- Provider Url : Set the LDAP server information in the format ldap://<AD_SERVER_IP>:<LDAP_PORT>. (javax.naming.Context.PROVIDER_URL)
+- Provider Url : Set the LDAP server information in the format ldap://&lt;AD_SERVER_IP&gt;:&lt;LDAP_PORT&gt;. (javax.naming.Context.PROVIDER_URL)
 
 ## SMTP Setting
 


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/17478634/129338759-316b79f3-f3ec-45b5-ab03-b5af45abb523.png)


## After
![image](https://user-images.githubusercontent.com/17478634/129337648-97e69b4d-b7eb-4fe9-9b40-3157ac115388.png)

If this PR was approved. I will also work on ko guide.
