### PR TITLE
Add FOSSLight Reuse link

### DIFF
--- a/learn/1_contribution.md
+++ b/learn/1_contribution.md
@@ -5,6 +5,7 @@ For improvements or bugs, please report by creating an issue in Git repository. 
 - [FOSSLight](https://github.com/fosslight/fosslight/issues)
 - [FOSSLight Dependency Scanner](https://github.com/fosslight/fosslight_dependency_scanner/issues)
 - [FOSSLight Source Scanner](https://github.com/fosslight/fosslight_source_scanner/issues)
+- [FOSSLight Reuse](https://github.com/fosslight/fosslight_reuse/issues)
 - [FOSSLight Guide](https://github.com/fosslight/fosslight-guide-en/issues)
 
 ## Contributing


### PR DESCRIPTION
Add FOSSLight Reuse link to 'Report an issue'.
<img width="886" alt="image" src="https://user-images.githubusercontent.com/69254943/133186000-a4e40579-a14a-4e2e-bd3a-7eb9a9fa93a8.png">
