### PR TITLE
Fix command option

### DIFF
--- a/scanner/3_dependency.md
+++ b/scanner/3_dependency.md
@@ -261,7 +261,7 @@ $ fosslight_dependency [option] <arg>
             -h                              Print help message.
             -v                              Print the version of the fosslight_dependency.
             -m <package_manager>            Enter the package manager.
-                                             (npm, maven, gradle, pip, pub, cocoapods, android, swift, carthage, go, nuget, helm)
+                                             (npm, maven, gradle, pypi, pub, cocoapods, android, swift, carthage, go, nuget, helm)
             -p <input_path>                 Enter the path where the script will be run.
             -o <output_path>                Output path
                                              (If you want to generate the specific file name, add the output path with file name.)


### PR DESCRIPTION
When I run `fosslight_dependency -m pip` as current documentation, it returns 
> [FOSSLIGHT_DEPENDENCY] You entered the unsupported package manager(pip).

It runs well with option `pypi` instead of `pip`.