### PR TITLE
Update link in documentation.

### DIFF
--- a/scanner/4_binary.md
+++ b/scanner/4_binary.md
@@ -27,7 +27,7 @@ To use the function to extract OSS information (OSS Name, OSS Version, License) 
 
 ## 🎉 How to install
 ### Method 1. Download the executable file.
-Download the executable file suitable for the OS. : [https://github.com/fosslight/fosslight_binary_scanner/releases]()
+Download the executable file suitable for the OS. : [Releases](https://github.com/fosslight/fosslight_binary_scanner/releases)
 ### Method 2. Install fosslight_binary based on Python environment.
 It can be installed using pip3. 
 0. (Only for windows) Install Microsoft Build Tools from https://visualstudio.microsoft.com/en/vs/older-downloads/ > Redistributables packages and Build Tools.


### PR DESCRIPTION
## Description
Fix one of the links in the documentation site that was pointing to itself.
![image](https://github.com/user-attachments/assets/b6800b98-3e14-4bc2-8b12-a5c81d983c04)



## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
